### PR TITLE
Refactor/domain refinement

### DIFF
--- a/application/src/main/java/com/arqivame/storage/application/file/session/chunk/write/DefaultWriteUploadSessionChunkUseCase.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/chunk/write/DefaultWriteUploadSessionChunkUseCase.java
@@ -73,7 +73,7 @@ public class DefaultWriteUploadSessionChunkUseCase extends WriteUploadSessionChu
 
         validation.validate(() -> file.initiateChunkWriting(sessionId, chunkIndex, storageService));
         eventDispatcher.notify(fileGateway.update(file));
-        if (validation.hasError())
+        if (validation.hasErrors())
             throw new RuntimeException("Cannot initiate chunk writing: " + validation.getErrors().toString());
 
     }
@@ -88,7 +88,7 @@ public class DefaultWriteUploadSessionChunkUseCase extends WriteUploadSessionChu
 
         validation.validate(() -> file.writeChunk(sessionId, chunkIndex, checksumValue, chunkData));
         eventDispatcher.notify(fileGateway.update(file));
-        if (validation.hasError())
+        if (validation.hasErrors())
             throw new RuntimeException("Cannot write chunk data: " + validation.getErrors().toString());
 
     }

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/ChunkIntegrityViolationException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/ChunkIntegrityViolationException.java
@@ -1,0 +1,17 @@
+package com.arqivame.storage.domain.exception;
+
+import java.util.List;
+
+public class ChunkIntegrityViolationException extends SilentDomainException {
+
+    private static final String MESSAGE = "Chunk integrity violation detected.";
+
+    private ChunkIntegrityViolationException() {
+        super(MESSAGE, List.of());
+    }
+
+    public static ChunkIntegrityViolationException create() {
+        return new ChunkIntegrityViolationException();
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/InvalidArgumentException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/InvalidArgumentException.java
@@ -1,0 +1,24 @@
+package com.arqivame.storage.domain.exception;
+
+import static java.util.Objects.isNull;
+
+import java.util.List;
+
+public class InvalidArgumentException extends SilentDomainException {
+
+    private static final String MESSAGE = "Invalid argument provided.";
+
+    protected InvalidArgumentException(final List<Error> errors) {
+        super(MESSAGE, isNull(errors) ? List.of() : List.copyOf(errors));
+    }
+
+    public static InvalidArgumentException with(final Error error) {
+        final List<Error> list = isNull(error) ? List.of() : List.of(error);
+        return new InvalidArgumentException(list);
+    }
+
+    public static InvalidArgumentException with(final List<Error> errors) {
+        return new InvalidArgumentException(errors);
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/InvalidStateException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/InvalidStateException.java
@@ -1,0 +1,30 @@
+package com.arqivame.storage.domain.exception;
+
+import static java.util.Objects.isNull;
+
+import java.util.List;
+
+import com.arqivame.storage.domain.Entity;
+
+public class InvalidStateException extends SilentDomainException {
+
+    private static final String MESSAGE = "[%s] in invalid state.";
+
+    protected <E extends Entity<?>> InvalidStateException(final Class<E> entityClass, final List<Error> errors) {
+        super(
+                MESSAGE.formatted(entityClass.getSimpleName()),
+                isNull(errors) ? List.of() : List.copyOf(errors));
+    }
+
+    public static <E extends Entity<?>> InvalidStateException with(final Class<E> entityClass, final Error error) {
+        final List<Error> list = isNull(error) ? List.of() : List.of(error);
+        return new InvalidStateException(entityClass, list);
+    }
+
+    public static <E extends Entity<?>> InvalidStateException with(
+            final Class<E> entityClass,
+            final List<Error> errors) {
+        return new InvalidStateException(entityClass, errors);
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/MaxConcurrentChunkWritesReachedException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/MaxConcurrentChunkWritesReachedException.java
@@ -1,0 +1,22 @@
+package com.arqivame.storage.domain.exception;
+
+import java.util.List;
+import java.util.Objects;
+
+public class MaxConcurrentChunkWritesReachedException extends SilentDomainException {
+
+    private static final String MESSAGE = "Maximum concurrent chunk writes reached [%d]";
+    private static final String ERROR = MESSAGE
+            + ", please wait for some chunk writes to complete before uploading more chunks";
+
+    private MaxConcurrentChunkWritesReachedException(final Integer maxConcurrentWrites) {
+        super(
+                MESSAGE.formatted(Objects.requireNonNull(maxConcurrentWrites)),
+                List.of(Error.with(ERROR.formatted(Objects.requireNonNull(maxConcurrentWrites)))));
+    }
+
+    public static MaxConcurrentChunkWritesReachedException create(final Integer maxConcurrentWrites) {
+        return new MaxConcurrentChunkWritesReachedException(maxConcurrentWrites);
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/NotFoundException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/NotFoundException.java
@@ -1,0 +1,35 @@
+package com.arqivame.storage.domain.exception;
+
+import java.util.List;
+
+import com.arqivame.storage.domain.Entity;
+import com.arqivame.storage.domain.Identifier;
+
+public class NotFoundException extends SilentDomainException {
+
+    private static final String MESSAGE_TEMPLATE = "[%S] not found";
+    private static final String ERROR_TEMPLATE = "[%s] with id [%s] not found";
+
+    private <E extends Entity<I>, I extends Identifier<?>> NotFoundException(
+            final Class<E> entityClass,
+            final I identifier) {
+        super(
+                MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()),
+                List.of(Error.with(
+                        ERROR_TEMPLATE.formatted(
+                                entityClass.getSimpleName(),
+                                identifier.getStringValue()))));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(final Entity<I> entity) {
+        return new NotFoundException(entity.getClass(), entity.getId());
+    }
+
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(
+            final Class<E> entityClass,
+            final I identifier) {
+        return new NotFoundException(entityClass, identifier);
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/NotFoundException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/NotFoundException.java
@@ -21,6 +21,12 @@ public class NotFoundException extends SilentDomainException {
                                 identifier.getStringValue()))));
     }
 
+    private <E extends Entity<I>, I extends Identifier<?>> NotFoundException(final Class<E> entityClass) {
+        super(
+                MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()),
+                List.of(Error.with(MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()))));
+    }
+
     @SuppressWarnings("unchecked")
     public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(final Entity<I> entity) {
         return new NotFoundException(entity.getClass(), entity.getId());
@@ -30,6 +36,10 @@ public class NotFoundException extends SilentDomainException {
             final Class<E> entityClass,
             final I identifier) {
         return new NotFoundException(entityClass, identifier);
+    }
+
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(final Class<E> entityClass) {
+        return new NotFoundException(entityClass);
     }
 
 }

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/SilentDomainException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/SilentDomainException.java
@@ -6,11 +6,20 @@ public abstract class SilentDomainException extends DomainException {
 
     private static final boolean VERBOSE = false;
 
-    protected SilentDomainException(String message, List<DomainException.Error> errors) {
+    protected SilentDomainException(final String message) {
+        super(message, null, null, VERBOSE);
+    }
+
+    protected SilentDomainException(
+            final String message,
+            final List<DomainException.Error> errors) {
         super(message, errors, null, VERBOSE);
     }
 
-    protected SilentDomainException(String message, List<DomainException.Error> errors, Throwable cause) {
+    protected SilentDomainException(
+            final String message,
+            final List<DomainException.Error> errors,
+            final Throwable cause) {
         super(message, errors, cause, VERBOSE);
     }
 

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/UploadSessionAlreadyOpenException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/UploadSessionAlreadyOpenException.java
@@ -1,0 +1,18 @@
+package com.arqivame.storage.domain.exception;
+
+import java.util.List;
+
+public class UploadSessionAlreadyOpenException extends SilentDomainException {
+
+    private static final String MESSAGE = "Session already open";
+    private static final String ERROR = MESSAGE + ", please close the current session before opening a new one";
+
+    private UploadSessionAlreadyOpenException() {
+        super(MESSAGE, List.of(Error.with(ERROR)));
+    }
+
+    public static UploadSessionAlreadyOpenException create() {
+        return new UploadSessionAlreadyOpenException();
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/ValidationException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/ValidationException.java
@@ -5,17 +5,16 @@ import java.util.List;
 import com.arqivame.storage.domain.validation.ValidationError;
 import com.arqivame.storage.domain.validation.handler.Notification;
 
-
 public class ValidationException extends SilentDomainException {
 
     private ValidationException(final String message, final List<DomainException.Error> errors) {
         super(message, List.copyOf(errors));
     }
 
-    public static ValidationException with(final String message, final Notification aNotification) {
+    public static ValidationException with(final String message, final Notification notification) {
         return new ValidationException(
                 message,
-                aNotification
+                notification
                         .getErrors()
                         .stream()
                         .map(ValidationError::toDomainError)

--- a/domain/src/main/java/com/arqivame/storage/domain/file/Chunk.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/Chunk.java
@@ -13,7 +13,9 @@ import com.arqivame.storage.domain.exception.DomainException.Error;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageKey;
 import com.arqivame.storage.domain.file.service.StorageWriter;
+import com.arqivame.storage.domain.validation.ValidationError;
 import com.arqivame.storage.domain.validation.ValidationHandler;
+import com.arqivame.storage.domain.validation.handler.Notification;
 
 public class Chunk extends Entity<ChunkID> {
 
@@ -44,6 +46,8 @@ public class Chunk extends Entity<ChunkID> {
         this.waitingForDeletion = waitingForDeletion;
         this.writtenAt = writtenAt;
         this.writer = Optional.ofNullable(writer);
+
+        selfValidate();
     }
 
     public static Chunk create(final Long index, final Long size) {
@@ -80,8 +84,22 @@ public class Chunk extends Entity<ChunkID> {
 
     @Override
     public void validate(final ValidationHandler handler) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'validate'");
+
+        if (Objects.isNull(index))
+            handler.append(ValidationError.with("Chunk index cannot be null."));
+
+        if (index < 0)
+            handler.append(ValidationError.with("Chunk index must be a non-negative value."));
+
+        if (Objects.isNull(size))
+            handler.append(ValidationError.with("Chunk size cannot be null."));
+
+        if (size < 0)
+            handler.append(ValidationError.with("Chunk size must be a non-negative value."));
+
+        if (Objects.isNull(status))
+            handler.append(ValidationError.with("Chunk status cannot be null."));
+
     }
 
     public Chunk assignWriter(final StorageWriter writer) {
@@ -182,6 +200,13 @@ public class Chunk extends Entity<ChunkID> {
 
     public Optional<StorageWriter> getWriter() {
         return writer;
+    }
+
+    private void selfValidate() {
+        final Notification notification = Notification.create();
+        validate(notification);
+        if (notification.hasErrors())
+            throw InvalidStateException.with(Chunk.class, notification.getDomainErrors());
     }
 
 }

--- a/domain/src/main/java/com/arqivame/storage/domain/file/Chunk.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/Chunk.java
@@ -6,6 +6,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.arqivame.storage.domain.Entity;
+import com.arqivame.storage.domain.exception.ChunkIntegrityViolationException;
+import com.arqivame.storage.domain.exception.InvalidArgumentException;
+import com.arqivame.storage.domain.exception.InvalidStateException;
+import com.arqivame.storage.domain.exception.DomainException.Error;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageKey;
 import com.arqivame.storage.domain.file.service.StorageWriter;
@@ -19,7 +23,6 @@ public class Chunk extends Entity<ChunkID> {
     private StorageKey storageKey;
     private Boolean waitingForDeletion;
 
-    // TODO precisa? validar
     private Instant writtenAt;
 
     private Optional<StorageWriter> writer;
@@ -83,12 +86,13 @@ public class Chunk extends Entity<ChunkID> {
 
     public Chunk assignWriter(final StorageWriter writer) {
 
-        if (waitingForDeletion)
-            throw new RuntimeException(
-                    "Cannot assign writer to a chunk marked for deletion: " + this.getId().getValue());
-
         if (Objects.isNull(writer))
-            throw new IllegalArgumentException("Writer cannot be null");
+            throw InvalidArgumentException.with(Error.with("Writer cannot be null"));
+
+        if (waitingForDeletion)
+            throw InvalidStateException.with(
+                    Chunk.class,
+                    Error.with("Cannot assign writer to a chunk marked for deletion: " + this.getId().getValue()));
 
         this.status = ChunkStatus.READY;
         this.writer = Optional.ofNullable(writer);
@@ -102,12 +106,15 @@ public class Chunk extends Entity<ChunkID> {
             final Long bytesPerSecondsWrittenRate) {
 
         if (waitingForDeletion)
-            throw new RuntimeException(
-                    "Cannot write a chunk marked for deletion: " + this.getId().getValue());
+            throw InvalidStateException.with(
+                    Chunk.class,
+                    Error.with("Cannot write a chunk marked for deletion: " + this.getId().getValue()));
 
         if (writer.isEmpty()) {
             this.status = ChunkStatus.FAILED;
-            throw new IllegalStateException("Chunk writer is not assigned");
+            throw InvalidStateException.with(
+                    Chunk.class,
+                    Error.with("Chunk writer is not assigned: " + this.getId().getValue()));
         }
 
         final Checksum streamChecksumValue = writer
@@ -121,7 +128,7 @@ public class Chunk extends Entity<ChunkID> {
 
         if (!streamChecksumValue.equals(checksumValue)) {
             status = ChunkStatus.FAILED;
-            throw new RuntimeException("Checksum mismatch after writing chunk");
+            throw ChunkIntegrityViolationException.create();
         }
 
         this.status = ChunkStatus.WRITTEN;

--- a/domain/src/main/java/com/arqivame/storage/domain/file/File.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/File.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import com.arqivame.storage.domain.AggregateRoot;
 import com.arqivame.storage.domain.event.Event;
 import com.arqivame.storage.domain.event.EventSource;
+import com.arqivame.storage.domain.exception.NotFoundException;
 import com.arqivame.storage.domain.exception.UploadSessionAlreadyOpenException;
 import com.arqivame.storage.domain.file.event.FileUploadSessionCanceledEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionChunksPhysicallyDeletedEvent;
@@ -111,10 +112,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     public File markUploadSessionForDeletion(final UploadSessionID sessionId) {
 
-        final UploadSession uploadSession = uploadSessions.stream()
-                .filter(session -> session.getId().equals(sessionId))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("No upload session with ID: " + sessionId));
+        final UploadSession uploadSession = fetchUploadSessionById(sessionId);
 
         uploadSession.markForDeletion();
         events.add(FileUploadSessionMarkedForDeletionEvent.create(this, uploadSession));
@@ -171,7 +169,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
                 .stream()
                 .filter(session -> session.getId().equals(sessionId))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("No upload session with ID: " + sessionId));
+                .orElseThrow(() -> NotFoundException.create(UploadSession.class, sessionId));
     }
 
     public Checksum getChecksum() {

--- a/domain/src/main/java/com/arqivame/storage/domain/file/File.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/File.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import com.arqivame.storage.domain.AggregateRoot;
 import com.arqivame.storage.domain.event.Event;
 import com.arqivame.storage.domain.event.EventSource;
+import com.arqivame.storage.domain.exception.UploadSessionAlreadyOpenException;
 import com.arqivame.storage.domain.file.event.FileUploadSessionCanceledEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionChunksPhysicallyDeletedEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionMarkedForDeletionEvent;
@@ -91,8 +92,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
                 .anyMatch(status -> UploadSessionStatus.ACTIVE.equals(status));
 
         if (hasAnySessionActive)
-            throw new RuntimeException(
-                    "Session already open, please close the current session before opening a new one");
+            throw UploadSessionAlreadyOpenException.create();
 
         final UploadSession session = UploadSession.create(
                 this,

--- a/domain/src/main/java/com/arqivame/storage/domain/file/File.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/File.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import com.arqivame.storage.domain.AggregateRoot;
 import com.arqivame.storage.domain.event.Event;
 import com.arqivame.storage.domain.event.EventSource;
+import com.arqivame.storage.domain.exception.InvalidStateException;
 import com.arqivame.storage.domain.exception.NotFoundException;
 import com.arqivame.storage.domain.exception.UploadSessionAlreadyOpenException;
 import com.arqivame.storage.domain.file.event.FileUploadSessionCanceledEvent;
@@ -19,7 +20,9 @@ import com.arqivame.storage.domain.file.event.FileUploadSessionChunksPhysicallyD
 import com.arqivame.storage.domain.file.event.FileUploadSessionMarkedForDeletionEvent;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageWriter;
+import com.arqivame.storage.domain.validation.ValidationError;
 import com.arqivame.storage.domain.validation.ValidationHandler;
+import com.arqivame.storage.domain.validation.handler.Notification;
 
 public class File extends AggregateRoot<FileID> implements EventSource {
 
@@ -40,7 +43,10 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         this.size = size;
         this.uploadSessions = Objects.isNull(uploadSessions) ? new HashSet<>() : new HashSet<>(uploadSessions);
 
-        this.events = Objects.isNull(events) ? new java.util.LinkedList<>() : new java.util.LinkedList<>(events);
+        this.events = Objects.isNull(events) ? new LinkedList<>() : new LinkedList<>(events);
+
+        selfValidate();
+
     }
 
     public static File create(
@@ -70,8 +76,14 @@ public class File extends AggregateRoot<FileID> implements EventSource {
     }
 
     @Override
-    public void validate(ValidationHandler handler) {
-        throw new UnsupportedOperationException("Unimplemented method 'validate'");
+    public void validate(final ValidationHandler handler) {
+
+        if (Objects.isNull(size))
+            handler.append(ValidationError.with("File size cannot be null."));
+
+        if (size < 0)
+            handler.append(ValidationError.with("File size must be a non-negative value."));
+
     }
 
     @Override
@@ -186,6 +198,13 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     public Queue<Event<?>> getEvents() {
         return new LinkedList<>(events);
+    }
+
+    private void selfValidate() {
+        final Notification notification = Notification.create();
+        validate(notification);
+        if (notification.hasErrors())
+            throw InvalidStateException.with(File.class, notification.getDomainErrors());
     }
 
 }

--- a/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
@@ -8,10 +8,17 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.arqivame.storage.domain.Entity;
+import com.arqivame.storage.domain.exception.InvalidArgumentException;
+import com.arqivame.storage.domain.exception.InvalidStateException;
+import com.arqivame.storage.domain.exception.MaxConcurrentChunkWritesReachedException;
+import com.arqivame.storage.domain.exception.ValidationException;
+import com.arqivame.storage.domain.exception.DomainException.Error;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageKey;
 import com.arqivame.storage.domain.file.service.StorageWriter;
+import com.arqivame.storage.domain.validation.ValidationError;
 import com.arqivame.storage.domain.validation.ValidationHandler;
+import com.arqivame.storage.domain.validation.handler.Notification;
 
 public class UploadSession extends Entity<UploadSessionID> {
 
@@ -58,6 +65,12 @@ public class UploadSession extends Entity<UploadSessionID> {
         this.waitingForDeletion = waitingForDeletion;
 
         this.version = version;
+
+        final Notification notification = Notification.create();
+        validate(notification);
+        if (notification.hasErrors())
+            throw ValidationException.with("Invalid upload session", notification);
+
     }
 
     public static UploadSession create(
@@ -68,19 +81,6 @@ public class UploadSession extends Entity<UploadSessionID> {
             final Duration maxIdleTime,
             final Long maxBytesPerSecondTransferRatePerChunk,
             final Integer maxChunksAtSameTime) {
-
-        if (totalChunks <= 0)
-            throw new IllegalArgumentException("Total chunks must be greater than zero");
-
-        if (maxIdleTime.isNegative() || maxIdleTime.isZero())
-            throw new IllegalArgumentException("Max idle time must be greater than zero");
-
-        if (maxBytesPerSecondTransferRatePerChunk <= 0)
-            throw new IllegalArgumentException(
-                    "Max bytes per second transfer rate per chunk must be greater than zero");
-
-        if (maxChunksAtSameTime <= 0)
-            throw new IllegalArgumentException("Max chunks at same time must be greater than zero");
 
         return new UploadSession(
                 UploadSessionID.unique(),
@@ -130,14 +130,29 @@ public class UploadSession extends Entity<UploadSessionID> {
 
     @Override
     public void validate(final ValidationHandler handler) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'validate'");
+
+        if (totalChunks <= 0)
+            handler.append(ValidationError.with("Total chunks must be greater than zero"));
+
+        if (maxIdleTime.isNegative() || maxIdleTime.isZero())
+            handler.append(ValidationError.with("Max idle time must be greater than zero"));
+
+        if (maxBytesPerSecondTransferRatePerChunk <= 0)
+            handler.append(
+                    ValidationError.with("Max bytes per second transfer rate per chunk must be greater than zero"));
+
+        if (maxChunksAtSameTime <= 0)
+            handler.append(ValidationError.with("Max chunks at same time must be greater than zero"));
+
     }
 
     public UploadSession initiateChunkWriting(final Long chunkIndex, final StorageWriter writer) {
 
         if (UploadSessionStatus.CANCELED.equals(this.status))
-            throw new RuntimeException("Cannot write chunk to a canceled upload session: " + this.getId().getValue());
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot write chunk to a canceled upload session."));
 
         final Long writingChunksCount = chunks
                 .stream()
@@ -145,7 +160,7 @@ public class UploadSession extends Entity<UploadSessionID> {
                 .count();
 
         if (writingChunksCount >= maxChunksAtSameTime)
-            throw new RuntimeException("Maximum number of chunks being written reached: " + maxChunksAtSameTime);
+            throw MaxConcurrentChunkWritesReachedException.create(maxChunksAtSameTime);
 
         chunks
                 .stream()
@@ -163,7 +178,10 @@ public class UploadSession extends Entity<UploadSessionID> {
             final InputStream inputStream) {
 
         if (UploadSessionStatus.CANCELED.equals(this.status))
-            throw new RuntimeException("Cannot write chunk to a canceled upload session: " + this.getId().getValue());
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot write chunk to a canceled upload session."));
 
         final StorageKey key = StorageKey.from(getFile(), getId(), chunkIndex);
 
@@ -186,12 +204,16 @@ public class UploadSession extends Entity<UploadSessionID> {
 
         // TODO validar essa regra de negocio
         if (UploadSessionStatus.ACTIVE.equals(this.status))
-            throw new IllegalStateException(
-                    "Cannot mark an active upload session for deletion: " + this.getId().getValue());
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot mark an active upload session for deletion."));
 
         if (UploadSessionStatus.PROCESSING.equals(this.status))
-            throw new IllegalStateException(
-                    "Cannot mark a processing upload session for deletion: " + this.getId().getValue());
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot mark a processing upload session for deletion."));
 
         chunks.forEach(Chunk::markForDeletion);
 
@@ -212,7 +234,7 @@ public class UploadSession extends Entity<UploadSessionID> {
     private Chunk createChunk(final Long index) {
 
         if (index < 0 || index >= totalChunks)
-            throw new IllegalArgumentException("Chunk index out of bounds: " + index);
+            throw InvalidArgumentException.with(Error.with("Chunk index out of bounds: " + index));
 
         final Long size = (index == totalChunks - 1) ? lastChunkSize : chunkSize;
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
@@ -8,11 +8,11 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.arqivame.storage.domain.Entity;
+import com.arqivame.storage.domain.exception.DomainException.Error;
 import com.arqivame.storage.domain.exception.InvalidArgumentException;
 import com.arqivame.storage.domain.exception.InvalidStateException;
 import com.arqivame.storage.domain.exception.MaxConcurrentChunkWritesReachedException;
-import com.arqivame.storage.domain.exception.ValidationException;
-import com.arqivame.storage.domain.exception.DomainException.Error;
+import com.arqivame.storage.domain.exception.NotFoundException;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageKey;
 import com.arqivame.storage.domain.file.service.StorageWriter;
@@ -66,10 +66,7 @@ public class UploadSession extends Entity<UploadSessionID> {
 
         this.version = version;
 
-        final Notification notification = Notification.create();
-        validate(notification);
-        if (notification.hasErrors())
-            throw ValidationException.with("Invalid upload session", notification);
+        selfValidate();
 
     }
 
@@ -189,7 +186,7 @@ public class UploadSession extends Entity<UploadSessionID> {
                 .stream()
                 .filter(chunk -> chunk.getIndex().equals(chunkIndex))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("Chunk not found: " + chunkIndex))
+                .orElseThrow(() -> NotFoundException.create(Chunk.class))
                 .write(key, inputStream, checksumValue, maxBytesPerSecondTransferRatePerChunk);
 
         return this;
@@ -242,6 +239,13 @@ public class UploadSession extends Entity<UploadSessionID> {
         this.chunks.add(chunk);
 
         return chunk;
+    }
+
+    private void selfValidate() {
+        final Notification notification = Notification.create();
+        validate(notification);
+        if (notification.hasErrors())
+            throw InvalidStateException.with(UploadSession.class, notification.getDomainErrors());
     }
 
     public Boolean isComplete() {

--- a/domain/src/main/java/com/arqivame/storage/domain/validation/ValidationHandler.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/validation/ValidationHandler.java
@@ -14,7 +14,7 @@ public interface ValidationHandler {
 
     List<ValidationError> getErrors();
 
-    default boolean hasError() {
+    default boolean hasErrors() {
         return getErrors() != null && !getErrors().isEmpty();
     }
 

--- a/domain/src/main/java/com/arqivame/storage/domain/validation/ValidationHandler.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/validation/ValidationHandler.java
@@ -1,6 +1,10 @@
 package com.arqivame.storage.domain.validation;
 
+import static java.util.Objects.requireNonNullElse;
+
 import java.util.List;
+
+import com.arqivame.storage.domain.exception.DomainException;
 
 public interface ValidationHandler {
 
@@ -16,6 +20,15 @@ public interface ValidationHandler {
 
     default boolean hasErrors() {
         return getErrors() != null && !getErrors().isEmpty();
+    }
+
+    default List<DomainException.Error> getDomainErrors() {
+        return requireNonNullElse(
+                getErrors()
+                        .stream()
+                        .map(ValidationError::toDomainError)
+                        .toList(),
+                List.of());
     }
 
     @FunctionalInterface


### PR DESCRIPTION
# Refatora exceções e validações no domínio de upload

Este PR fortalece o domínio de upload ao substituir exceções genéricas por **exceções de domínio específicas e descritivas**, tornando regras de negócio e transições de estado explícitas no modelo.

## O que muda

* Remoção de `RuntimeException`, `IllegalArgumentException` e `IllegalStateException` do domínio
* Introdução de exceções de domínio para estados inválidos, limites de concorrência, integridade de chunk e entidades inexistentes
* Revisão dos fluxos de `UploadSession` e `Chunk` para explicitar invariantes
* Validações adicionadas na criação de entidades
* Padronização da API de validação (`hasErrors()`)

## Resultado

* Erros mais claros e orientados ao negócio
* Fluxos mais previsíveis e fáceis de manter
* Domínio mais expressivo e consistente

### Fora de escopo: infraestrutura, contratos externos e performance.

