### PR TITLE
Padroniza nomenclatura de ENTITY em eventos de upload

### DIFF
--- a/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionCanceledEvent.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionCanceledEvent.java
@@ -16,7 +16,7 @@ import com.arqivame.storage.domain.file.UploadSession;
 
 public class FileUploadSessionCanceledEvent extends Event<FileUploadSessionCanceledEvent.Data> {
 
-    private static final String ENTITY = "file.upload-session";
+    private static final String ENTITY = "file:upload-session";
     private static final String ACTION = "canceled";
     private static final String VERSION = "0.0.1";
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionChunksPhysicallyDeletedEvent.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionChunksPhysicallyDeletedEvent.java
@@ -16,7 +16,7 @@ import com.arqivame.storage.domain.file.UploadSession;
 public class FileUploadSessionChunksPhysicallyDeletedEvent
         extends Event<FileUploadSessionChunksPhysicallyDeletedEvent.Data> {
 
-    private static final String ENTITY = "file.upload-session.chunks";
+    private static final String ENTITY = "file:upload-session:chunks";
     private static final String ACTION = "physically-deleted";
     private static final String VERSION = "0.0.1";
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionClosedEvent.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionClosedEvent.java
@@ -15,7 +15,7 @@ import com.arqivame.storage.domain.file.UploadSession;
 
 public class FileUploadSessionClosedEvent extends Event<FileUploadSessionClosedEvent.Data> {
 
-    private static final String ENTITY = "file.upload-session";
+    private static final String ENTITY = "file:upload-session";
     private static final String ACTION = "closed";
     private static final String VERSION = "0.0.1";
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionMarkedForDeletionEvent.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionMarkedForDeletionEvent.java
@@ -16,7 +16,7 @@ import com.arqivame.storage.domain.file.UploadSession;
 
 public class FileUploadSessionMarkedForDeletionEvent extends Event<FileUploadSessionMarkedForDeletionEvent.Data> {
 
-    private static final String ENTITY = "file.upload-session";
+    private static final String ENTITY = "file:upload-session";
     private static final String ACTION = "marked-for-deletion";
     private static final String VERSION = "0.0.1";
 


### PR DESCRIPTION
Padroniza a constante ENTITY para usar ```:``` em vez de ```.``` para separar as sub entidades dos eventos.