### PR TITLE
Adiciona fluxo de processamento de upload e merge de chunks

### DIFF
--- a/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/DefaultMergeUploadSessionChunksUseCase.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/DefaultMergeUploadSessionChunksUseCase.java
@@ -1,0 +1,65 @@
+package com.arqivame.storage.application.file.session.chunk.merge;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.arqivame.storage.domain.event.EventDispatcher;
+import com.arqivame.storage.domain.exception.MergeChunksException;
+import com.arqivame.storage.domain.exception.NotFoundException;
+import com.arqivame.storage.domain.file.File;
+import com.arqivame.storage.domain.file.FileGateway;
+import com.arqivame.storage.domain.file.FileID;
+import com.arqivame.storage.domain.file.UploadSession;
+import com.arqivame.storage.domain.file.UploadSessionID;
+import com.arqivame.storage.domain.file.service.ChunkMergeService;
+import com.arqivame.storage.domain.file.service.ChunkMergeService.MergeResult;
+import com.arqivame.storage.domain.file.service.StorageKey;
+
+public class DefaultMergeUploadSessionChunksUseCase extends MergeUploadSessionChunksUseCase {
+
+    private final EventDispatcher eventDispatcher;
+
+    private final FileGateway fileGateway;
+    private final ChunkMergeService chunkMergeService;
+
+    public DefaultMergeUploadSessionChunksUseCase(
+            final EventDispatcher eventDispatcher,
+            final FileGateway fileGateway,
+            final ChunkMergeService chunkMergeService) {
+        this.eventDispatcher = Objects.requireNonNull(eventDispatcher);
+        this.fileGateway = Objects.requireNonNull(fileGateway);
+        this.chunkMergeService = Objects.requireNonNull(chunkMergeService);
+    }
+
+    @Override
+    public void execute(final MergeUploadSessionChunksInput input) {
+
+        final FileID fileId = FileID.of(input.fileId());
+        final UploadSessionID sessionId = UploadSessionID.of(input.uploadSessionId());
+
+        final File file = fileGateway
+                .findById(fileId)
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId));
+
+        final UploadSession uploadSession = file.fetchUploadSessionById(sessionId);
+
+        final StorageKey finalFileKey = StorageKey.from(fileId);
+        final Set<ChunkMergeService.ChunkInfo> chunks = uploadSession
+                .getChunks()
+                .stream()
+                .map(ChunkMergeService.ChunkInfo::with)
+                .collect(java.util.stream.Collectors.toSet());
+        final Long firstChunkSize = uploadSession.getChunkSize();
+
+        final MergeResult mergeResult = chunkMergeService.mergeChunks(finalFileKey, chunks, firstChunkSize);
+
+        if (!mergeResult.allChunksMerged())
+            throw MergeChunksException.create();
+
+        eventDispatcher.notify(
+                fileGateway.update(
+                        file.completeUploadSessionProcessing(sessionId).markUploadSessionForDeletion(sessionId)));
+
+    }
+
+}

--- a/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/MergeUploadSessionChunksInput.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/MergeUploadSessionChunksInput.java
@@ -1,0 +1,7 @@
+package com.arqivame.storage.application.file.session.chunk.merge;
+
+import java.util.UUID;
+
+public record MergeUploadSessionChunksInput(UUID fileId, UUID uploadSessionId) {
+
+}

--- a/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/MergeUploadSessionChunksUseCase.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/chunk/merge/MergeUploadSessionChunksUseCase.java
@@ -1,0 +1,9 @@
+package com.arqivame.storage.application.file.session.chunk.merge;
+
+import com.arqivame.storage.application.UnitUseCase;
+
+public abstract class MergeUploadSessionChunksUseCase extends UnitUseCase<MergeUploadSessionChunksInput> {
+
+
+
+}

--- a/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/DefaultInitiateUploadSessionProcessingUseCase.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/DefaultInitiateUploadSessionProcessingUseCase.java
@@ -1,0 +1,39 @@
+package com.arqivame.storage.application.file.session.process.initiate;
+
+import java.util.Objects;
+
+import com.arqivame.storage.domain.event.EventDispatcher;
+import com.arqivame.storage.domain.exception.NotFoundException;
+import com.arqivame.storage.domain.file.File;
+import com.arqivame.storage.domain.file.FileGateway;
+import com.arqivame.storage.domain.file.FileID;
+import com.arqivame.storage.domain.file.UploadSessionID;
+
+public class DefaultInitiateUploadSessionProcessingUseCase extends InitiateUploadSessionProcessingUseCase {
+
+    private final EventDispatcher eventDispatcher;
+
+    private final FileGateway fileGateway;
+
+    public DefaultInitiateUploadSessionProcessingUseCase(
+            final EventDispatcher eventDispatcher,
+            final FileGateway fileGateway) {
+        this.eventDispatcher = Objects.requireNonNull(eventDispatcher);
+        this.fileGateway = Objects.requireNonNull(fileGateway);
+    }
+
+    @Override
+    public void execute(final InitiateUploadSessionProcessingInput input) {
+
+        final FileID fileId = FileID.of(input.fileId());
+        final UploadSessionID sessionId = UploadSessionID.of(input.uploadSessionId());
+
+        final File file = fileGateway
+                .findById(fileId)
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId));
+
+        eventDispatcher.notify(fileGateway.update(file.initUploadSessionProcessing(sessionId)));
+
+    }
+
+}

--- a/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/InitiateUploadSessionProcessingInput.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/InitiateUploadSessionProcessingInput.java
@@ -1,0 +1,7 @@
+package com.arqivame.storage.application.file.session.process.initiate;
+
+import java.util.UUID;
+
+public record InitiateUploadSessionProcessingInput(UUID fileId, UUID uploadSessionId) {
+
+}

--- a/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/InitiateUploadSessionProcessingUseCase.java
+++ b/application/src/main/java/com/arqivame/storage/application/file/session/process/initiate/InitiateUploadSessionProcessingUseCase.java
@@ -1,0 +1,7 @@
+package com.arqivame.storage.application.file.session.process.initiate;
+
+import com.arqivame.storage.application.UnitUseCase;
+
+public abstract class InitiateUploadSessionProcessingUseCase extends UnitUseCase<InitiateUploadSessionProcessingInput> {
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/MergeChunksException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/MergeChunksException.java
@@ -1,0 +1,15 @@
+package com.arqivame.storage.domain.exception;
+
+public class MergeChunksException extends SilentDomainException {
+
+    private static final String MESSAGE = "An error occurred while merging file chunks";
+
+    private MergeChunksException() {
+        super(MESSAGE);
+    }
+
+    public static MergeChunksException create() {
+        return new MergeChunksException();
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/exception/UploadSessionAlreadyProcessingException.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/exception/UploadSessionAlreadyProcessingException.java
@@ -1,0 +1,15 @@
+package com.arqivame.storage.domain.exception;
+
+public class UploadSessionAlreadyProcessingException extends SilentDomainException {
+
+    private static final String MESSAGE = "Upload session is already being processed";
+
+    private UploadSessionAlreadyProcessingException() {
+        super(MESSAGE);
+    }
+
+    public static UploadSessionAlreadyProcessingException create() {
+        return new UploadSessionAlreadyProcessingException();
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/file/File.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/File.java
@@ -18,6 +18,7 @@ import com.arqivame.storage.domain.exception.UploadSessionAlreadyOpenException;
 import com.arqivame.storage.domain.file.event.FileUploadSessionCanceledEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionChunksPhysicallyDeletedEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionMarkedForDeletionEvent;
+import com.arqivame.storage.domain.file.event.FileUploadSessionProcessingInitiatedEvent;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageWriter;
 import com.arqivame.storage.domain.validation.ValidationError;
@@ -176,7 +177,28 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         return this;
     }
 
-    private UploadSession fetchUploadSessionById(final UploadSessionID sessionId) {
+    public File initUploadSessionProcessing(final UploadSessionID sessionId) {
+
+        final UploadSession session = fetchUploadSessionById(sessionId);
+        session.initiateProcessing();
+        events.add(FileUploadSessionProcessingInitiatedEvent.create(this, session));
+
+        return this;
+
+    }
+
+    public File completeUploadSessionProcessing(final UploadSessionID sessionId) {
+
+        final UploadSession session = fetchUploadSessionById(sessionId);
+        session.completeProcessing();
+        // Se colocar evento podemos até fazer um webhook ou notificação aqui
+        // events.add(FileUploadSessionProcessingCompletedEvent.create(this, session));
+
+        return this;
+
+    }
+
+    public UploadSession fetchUploadSessionById(final UploadSessionID sessionId) {
         return uploadSessions
                 .stream()
                 .filter(session -> session.getId().equals(sessionId))

--- a/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/UploadSession.java
@@ -13,6 +13,7 @@ import com.arqivame.storage.domain.exception.InvalidArgumentException;
 import com.arqivame.storage.domain.exception.InvalidStateException;
 import com.arqivame.storage.domain.exception.MaxConcurrentChunkWritesReachedException;
 import com.arqivame.storage.domain.exception.NotFoundException;
+import com.arqivame.storage.domain.exception.UploadSessionAlreadyProcessingException;
 import com.arqivame.storage.domain.file.service.StorageDeleter;
 import com.arqivame.storage.domain.file.service.StorageKey;
 import com.arqivame.storage.domain.file.service.StorageWriter;
@@ -215,6 +216,43 @@ public class UploadSession extends Entity<UploadSessionID> {
         chunks.forEach(Chunk::markForDeletion);
 
         waitingForDeletion = true;
+    }
+
+    public void initiateProcessing() {
+
+        if (UploadSessionStatus.PROCESSING.equals(this.status))
+            throw UploadSessionAlreadyProcessingException.create();
+
+        if (UploadSessionStatus.CANCELED.equals(this.status))
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot process a canceled upload session."));
+
+        if (UploadSessionStatus.COMPLETED.equals(this.status))
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot process a completed upload session."));
+
+        if (UploadSessionStatus.DELETED.equals(this.status))
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Cannot process a deleted upload session."));
+
+        this.status = UploadSessionStatus.PROCESSING;
+    }
+
+    public void completeProcessing() {
+
+        if (!UploadSessionStatus.PROCESSING.equals(this.status))
+            throw InvalidStateException
+                    .with(
+                            UploadSession.class,
+                            Error.with("Only processing upload sessions can be completed."));
+
+        this.status = UploadSessionStatus.COMPLETED;
     }
 
     public void physicallyDeleteChunks(final StorageDeleter storageDeleter) {

--- a/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionProcessingInitiatedEvent.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/event/FileUploadSessionProcessingInitiatedEvent.java
@@ -1,0 +1,58 @@
+package com.arqivame.storage.domain.file.event;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.arqivame.storage.domain.event.Event;
+import com.arqivame.storage.domain.event.EventEntity;
+import com.arqivame.storage.domain.event.EventMetadata;
+import com.arqivame.storage.domain.file.File;
+import com.arqivame.storage.domain.file.UploadSession;
+
+public class FileUploadSessionProcessingInitiatedEvent extends Event<FileUploadSessionProcessingInitiatedEvent.Data> {
+
+    private static final String ENTITY = "file:upload-session";
+    private static final String ACTION = "processing-initiated";
+    private static final String VERSION = "0.0.1";
+
+    private static final FileUploadSessionProcessingInitiatedEvent DEFAULT_INSTANCE = new FileUploadSessionProcessingInitiatedEvent();
+
+    private FileUploadSessionProcessingInitiatedEvent() {
+        super(EventMetadata.create(ENTITY, ACTION, VERSION, Instant.now(), Set.of()), null);
+    }
+
+    private FileUploadSessionProcessingInitiatedEvent(
+            Instant occurredAt,
+            Set<EventEntity> relatedEntities,
+            FileUploadSessionProcessingInitiatedEvent.Data data) {
+        super(EventMetadata.create(ENTITY, ACTION, VERSION, occurredAt, relatedEntities), data);
+    }
+
+    public record Data(UUID fileId, UUID sessionId) implements Serializable {
+
+        public static Data of(final File file, final UploadSession session) {
+            return new Data(file.getId().getValue(), session.getId().getValue());
+        }
+
+    }
+
+    public static FileUploadSessionProcessingInitiatedEvent create(final File file, final UploadSession session) {
+        return new FileUploadSessionProcessingInitiatedEvent(
+                Instant.now(),
+                Stream
+                        .of(EventEntity.of(file), EventEntity.of(session))
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet()),
+                Data.of(file, session));
+    }
+
+    public static String eventKey() {
+        return DEFAULT_INSTANCE.key();
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
@@ -1,5 +1,6 @@
 package com.arqivame.storage.domain.file.service;
 
+import java.util.Objects;
 import java.util.Set;
 
 import com.arqivame.storage.domain.exception.DomainException.Error;
@@ -9,7 +10,7 @@ import com.arqivame.storage.domain.file.Chunk;
 @FunctionalInterface
 public interface ChunkMergeService {
 
-    void mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks);
+    MergeResult mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks);
 
     public record ChunkInfo(StorageKey key, Long index) {
 
@@ -20,6 +21,22 @@ public interface ChunkMergeService {
                                     () -> InvalidStateException.with(Chunk.class,
                                             Error.with("Storage key is not set"))),
                     chunk.getIndex());
+        }
+
+    }
+
+    public record MergeResult(Boolean allChunksMerged, Set<ChunkInfo> nonMergedChunks) {
+
+        private MergeResult(final Set<ChunkInfo> nonMergedChunks) {
+            this(nonMergedChunks.isEmpty(), Set.copyOf(nonMergedChunks));
+        }
+
+        public static MergeResult allMerged() {
+            return new MergeResult(Set.of());
+        }
+
+        public static MergeResult partialMerge(final Set<ChunkInfo> nonMergedChunks) {
+            return new MergeResult(Objects.requireNonNullElse(nonMergedChunks, Set.of()));
         }
 
     }

--- a/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
@@ -1,0 +1,27 @@
+package com.arqivame.storage.domain.file.service;
+
+import java.util.Set;
+
+import com.arqivame.storage.domain.exception.DomainException.Error;
+import com.arqivame.storage.domain.exception.InvalidStateException;
+import com.arqivame.storage.domain.file.Chunk;
+
+@FunctionalInterface
+public interface ChunkMergeService {
+
+    void mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks);
+
+    public record ChunkInfo(StorageKey key, Long index) {
+
+        public static ChunkInfo with(final Chunk chunk) {
+            return new ChunkInfo(
+                    chunk.getStorageKey()
+                            .orElseThrow(
+                                    () -> InvalidStateException.with(Chunk.class,
+                                            Error.with("Storage key is not set"))),
+                    chunk.getIndex());
+        }
+
+    }
+
+}

--- a/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
@@ -10,9 +10,9 @@ import com.arqivame.storage.domain.file.Chunk;
 @FunctionalInterface
 public interface ChunkMergeService {
 
-    MergeResult mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks);
+    MergeResult mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks, Long firstChunkSize, Long lastChunkSize);
 
-    public record ChunkInfo(StorageKey key, Long index) {
+    public record ChunkInfo(StorageKey key, Long size, Long index) {
 
         public static ChunkInfo with(final Chunk chunk) {
             return new ChunkInfo(
@@ -20,6 +20,7 @@ public interface ChunkMergeService {
                             .orElseThrow(
                                     () -> InvalidStateException.with(Chunk.class,
                                             Error.with("Storage key is not set"))),
+                    chunk.getSize(),
                     chunk.getIndex());
         }
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/service/ChunkMergeService.java
@@ -10,17 +10,17 @@ import com.arqivame.storage.domain.file.Chunk;
 @FunctionalInterface
 public interface ChunkMergeService {
 
-    MergeResult mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks, Long firstChunkSize, Long lastChunkSize);
+    MergeResult mergeChunks(StorageKey finalFileKey, Set<ChunkInfo> chunks, Long firstChunkSize);
 
-    public record ChunkInfo(StorageKey key, Long size, Long index) {
+    public record ChunkInfo(StorageKey key, Long index) {
 
         public static ChunkInfo with(final Chunk chunk) {
             return new ChunkInfo(
                     chunk.getStorageKey()
                             .orElseThrow(
-                                    () -> InvalidStateException.with(Chunk.class,
+                                    () -> InvalidStateException.with(
+                                            Chunk.class,
                                             Error.with("Storage key is not set"))),
-                    chunk.getSize(),
                     chunk.getIndex());
         }
 

--- a/domain/src/main/java/com/arqivame/storage/domain/file/service/StorageKey.java
+++ b/domain/src/main/java/com/arqivame/storage/domain/file/service/StorageKey.java
@@ -38,6 +38,16 @@ public final class StorageKey {
                 });
     }
 
+    public static StorageKey from(final FileID file) {
+
+        return new StorageKey(
+                new String[] {
+                        "files",
+                        file.getStringValue(),
+                        "data"
+                });
+    }
+
     public static StorageKey of(final String fullKey) {
         if (Objects.isNull(fullKey) || fullKey.isBlank())
             throw InvalidArgumentException.with(Error.with("Full key cannot be null or blank"));

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/api/controller/TestController.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/api/controller/TestController.java
@@ -20,6 +20,8 @@ import com.arqivame.storage.application.file.session.chunk.write.WriteUploadSess
 import com.arqivame.storage.application.file.session.chunk.write.WriteUploadSessionChunkUseCase;
 import com.arqivame.storage.application.file.session.create.CreateUploadSessionInput;
 import com.arqivame.storage.application.file.session.create.CreateUploadSessionUseCase;
+import com.arqivame.storage.application.file.session.process.initiate.InitiateUploadSessionProcessingInput;
+import com.arqivame.storage.application.file.session.process.initiate.InitiateUploadSessionProcessingUseCase;
 import com.arqivame.storage.domain.file.Checksum;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,14 +33,17 @@ public class TestController {
     private final CreateUploadSessionUseCase createUploadSessionUseCase;
     private final WriteUploadSessionChunkUseCase writeUploadSessionChunkUseCase;
     private final CancelUploadSessionUseCase cancelUploadSessionUseCase;
+    private final InitiateUploadSessionProcessingUseCase initiateUploadSessionProcessingUseCase;
 
     public TestController(
             CreateUploadSessionUseCase createUploadSessionUseCase,
             WriteUploadSessionChunkUseCase writeUploadSessionChunkUseCase,
-            CancelUploadSessionUseCase cancelUploadSessionUseCase) {
+            CancelUploadSessionUseCase cancelUploadSessionUseCase,
+            InitiateUploadSessionProcessingUseCase initiateUploadSessionProcessingUseCase) {
         this.createUploadSessionUseCase = createUploadSessionUseCase;
         this.writeUploadSessionChunkUseCase = writeUploadSessionChunkUseCase;
         this.cancelUploadSessionUseCase = cancelUploadSessionUseCase;
+        this.initiateUploadSessionProcessingUseCase = initiateUploadSessionProcessingUseCase;
     }
 
     @PutMapping(value = "{fileId}/sessions/{sessionId}/chunks/{chunkPart}", consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
@@ -75,6 +80,17 @@ public class TestController {
         cancelUploadSessionUseCase.execute(input);
 
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(value = "{fileId}/sessions/{sessionId}/complete")
+    public ResponseEntity<?> completeSession(
+            @PathVariable UUID fileId,
+            @PathVariable UUID sessionId) throws IOException {
+
+        initiateUploadSessionProcessingUseCase.execute(new InitiateUploadSessionProcessingInput(fileId, sessionId));
+
+        return ResponseEntity.ok().build();
+
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
@@ -16,6 +16,10 @@ public final class FileSystemUtils {
     private FileSystemUtils() {
     }
 
+    public static Boolean exists(final Path filePath) {
+        return Files.exists(filePath);
+    }
+
     public static void write(
             final Path outputLocation,
             final InputStream content,

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
@@ -31,7 +31,7 @@ public final class FileSystemUtils {
             Files.copy(inputStream, destinationFile, options);
 
         } catch (FileAlreadyExistsException e) {
-            throw new IllegalArgumentException("File already exists: " + destinationFile.toString(), e);
+            throw InternalErrorException.with("File already exists: " + destinationFile.toString(), e);
         } catch (IOException e) {
             throw InternalErrorException.with("Failed to write file.", e);
         }
@@ -46,41 +46,34 @@ public final class FileSystemUtils {
         }
     }
 
-    public static void append(final Path targetFile, final SequentialIterator<Path> sourceFiles) {
+    public static FileChannel opeChannel(final Path path, final StandardOpenOption... options) {
+        try {
+            return FileChannel.open(path, options);
+        } catch (IOException e) {
+            throw InternalErrorException.with("Failed to open file channel: " + path.toString(), e);
+        }
+    }
 
-        // TODO melhorar tratamento de erros
-        targetFile.getParent().toFile().mkdirs();
+    public static void append(
+            final Long startPosition,
+            final FileChannel targetChannel,
+            final FileChannel sourceChannel) {
 
-        try (final FileChannel outputChannel = FileChannel.open(
-                targetFile,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE)) {
+        try {
 
-            while (sourceFiles.hasNext()) {
-                try (final FileChannel inputChannel = FileChannel.open(sourceFiles.next(), StandardOpenOption.READ)) {
-                    append(outputChannel.position(), outputChannel, inputChannel);
-                }
+            targetChannel.position(startPosition);
+
+            Long inputSize = sourceChannel.size();
+            Long trasferredBytes = 0L;
+            while (trasferredBytes < inputSize) {
+                trasferredBytes += sourceChannel.transferTo(
+                        trasferredBytes,
+                        inputSize - trasferredBytes,
+                        targetChannel);
             }
 
         } catch (Exception e) {
-            throw InternalErrorException.with("Failed to append file into " + targetFile.toString(), e);
-        }
-
-        System.out.println("File appended successfully to " + targetFile.toString());
-
-    }
-
-    private static void append(
-            final Long startPosition,
-            final FileChannel targetChannel,
-            final FileChannel sourceChannel) throws Exception {
-
-        targetChannel.position(startPosition);
-
-        Long inputSize = sourceChannel.size();
-        Long trasferredBytes = 0L;
-        while (trasferredBytes < inputSize) {
-            trasferredBytes += sourceChannel.transferTo(trasferredBytes, inputSize - trasferredBytes, targetChannel);
+            throw InternalErrorException.with("Failed to append file channels.", e);
         }
 
     }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
@@ -37,4 +37,12 @@ public final class FileSystemUtils {
 
     }
 
+    public static void delete(final Path filePath) {
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            throw InternalErrorException.with("Failed to delete file: " + filePath.toString(), e);
+        }
+    }
+
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
@@ -2,10 +2,12 @@ package com.arqivame.storage.infrastructure.commons;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.nio.file.CopyOption;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import com.arqivame.storage.domain.exception.InternalErrorException;
 
@@ -43,6 +45,48 @@ public final class FileSystemUtils {
         } catch (IOException e) {
             throw InternalErrorException.with("Failed to delete file: " + filePath.toString(), e);
         }
+    }
+
+    public static void append(final Path targetFile, final SequentialIterator<Path> sourceFiles) {
+
+        try (final FileChannel outputChannel = FileChannel.open(
+                targetFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE)) {
+
+            while (sourceFiles.hasNext()) {
+                try (final FileChannel inputChannel = FileChannel.open(sourceFiles.next(), StandardOpenOption.READ)) {
+
+                    final Long startPosition = outputChannel.position();// TODO ver se isso ta certo
+                    final Long endPosition = append(startPosition, outputChannel, inputChannel);
+                    outputChannel.position(endPosition);
+
+                }
+            }
+
+        } catch (Exception e) {
+            throw InternalErrorException.with("Failed to append file into " + targetFile.toString(), e);
+        }
+
+    }
+
+    private static Long append(
+            final Long startPosition,
+            final FileChannel targetChannel,
+            final FileChannel sourceChannel) throws Exception {
+
+        targetChannel.position(startPosition);
+
+        Long inputSize = sourceChannel.size();
+        Long trasferredBytes = 0L;
+        while (trasferredBytes < inputSize) {
+            trasferredBytes += sourceChannel.transferTo(trasferredBytes, inputSize - trasferredBytes, targetChannel);
+        }
+
+        final Long endPosition = targetChannel.position() + inputSize;
+        targetChannel.position(endPosition);
+
+        return endPosition;
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/FileSystemUtils.java
@@ -17,15 +17,14 @@ public final class FileSystemUtils {
     }
 
     public static void write(
-            final Path location,
-            final String fileName,
+            final Path outputLocation,
             final InputStream content,
             final CopyOption... options) {
 
         if (content == null)
             throw new IllegalArgumentException("Failed to write empty file.");
 
-        final Path destinationFile = location.resolve(fileName).normalize().toAbsolutePath();
+        final Path destinationFile = outputLocation.normalize().toAbsolutePath();
 
         try (InputStream inputStream = content) {
             Files.createDirectories(destinationFile.getParent());
@@ -49,6 +48,9 @@ public final class FileSystemUtils {
 
     public static void append(final Path targetFile, final SequentialIterator<Path> sourceFiles) {
 
+        // TODO melhorar tratamento de erros
+        targetFile.getParent().toFile().mkdirs();
+
         try (final FileChannel outputChannel = FileChannel.open(
                 targetFile,
                 StandardOpenOption.CREATE,
@@ -56,11 +58,7 @@ public final class FileSystemUtils {
 
             while (sourceFiles.hasNext()) {
                 try (final FileChannel inputChannel = FileChannel.open(sourceFiles.next(), StandardOpenOption.READ)) {
-
-                    final Long startPosition = outputChannel.position();// TODO ver se isso ta certo
-                    final Long endPosition = append(startPosition, outputChannel, inputChannel);
-                    outputChannel.position(endPosition);
-
+                    append(outputChannel.position(), outputChannel, inputChannel);
                 }
             }
 
@@ -68,9 +66,11 @@ public final class FileSystemUtils {
             throw InternalErrorException.with("Failed to append file into " + targetFile.toString(), e);
         }
 
+        System.out.println("File appended successfully to " + targetFile.toString());
+
     }
 
-    private static Long append(
+    private static void append(
             final Long startPosition,
             final FileChannel targetChannel,
             final FileChannel sourceChannel) throws Exception {
@@ -83,10 +83,6 @@ public final class FileSystemUtils {
             trasferredBytes += sourceChannel.transferTo(trasferredBytes, inputSize - trasferredBytes, targetChannel);
         }
 
-        final Long endPosition = targetChannel.position() + inputSize;
-        targetChannel.position(endPosition);
-
-        return endPosition;
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/SequentialIterator.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/SequentialIterator.java
@@ -1,0 +1,79 @@
+package com.arqivame.storage.infrastructure.commons;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public final class SequentialIterator<T> implements Iterator<T> {
+
+    private final ConcurrentHashMap<Long, T> items;
+    private AtomicLong actualPosition;
+
+    public static <T> SequentialIterator<T> of(final Set<Item<T>> items) {
+        return new SequentialIterator<>(items);
+    }
+
+    private SequentialIterator(final Set<Item<T>> items) {
+
+        validate(items);
+
+        this.actualPosition = new AtomicLong(0L);
+        this.items = new ConcurrentHashMap<>(
+                items
+                        .stream()
+                        .collect(Collectors
+                                .toMap(
+                                        item -> item.position,
+                                        item -> item.value)));
+
+    }
+
+    private static <T> void validate(final Set<Item<T>> items) {
+
+        if (Objects.isNull(items) || items.isEmpty())
+            throw new IllegalArgumentException("Items cannot be null or empty.");
+
+        final List<Long> positions = items.stream()
+                .map(Item::position)
+                .sorted()
+                .toList();
+
+        if (positions.get(0) != 0L)
+            throw new IllegalArgumentException(
+                    "Sequence must start at position 0, but starts at " + positions.get(0));
+
+        for (int i = 1; i < positions.size(); i++) {
+            long expected = positions.get(i - 1) + 1;
+            if (positions.get(i) != expected) {
+                throw new IllegalArgumentException(
+                        "Invalid sequence. Expected position " + expected +
+                                " but found " + positions.get(i));
+            }
+        }
+    }
+
+    public boolean hasNext() {
+        return items.containsKey(actualPosition.get());
+    }
+
+    public T next() {
+        final Long position = actualPosition.getAndIncrement();
+        final T item = items.get(position);
+        if (Objects.isNull(item))
+            throw new IllegalStateException("No more items available at position: " + position);
+        return item;
+    }
+
+    public static record Item<T>(T value, Long position) {
+
+        public static <T> Item<T> of(final T value, final Long position) {
+            return new Item<>(value, position);
+        }
+
+    }
+
+}

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/SequentialIterator.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/commons/SequentialIterator.java
@@ -34,7 +34,7 @@ public final class SequentialIterator<T> implements Iterator<T> {
 
     private static <T> void validate(final Set<Item<T>> items) {
 
-        if (Objects.isNull(items) || items.isEmpty())
+        if (items == null || items.isEmpty())
             throw new IllegalArgumentException("Items cannot be null or empty.");
 
         final List<Long> positions = items.stream()
@@ -42,16 +42,14 @@ public final class SequentialIterator<T> implements Iterator<T> {
                 .sorted()
                 .toList();
 
-        if (positions.get(0) != 0L)
-            throw new IllegalArgumentException(
-                    "Sequence must start at position 0, but starts at " + positions.get(0));
-
         for (int i = 1; i < positions.size(); i++) {
-            long expected = positions.get(i - 1) + 1;
+            final long expected = positions.get(i - 1) + 1;
             if (positions.get(i) != expected) {
                 throw new IllegalArgumentException(
-                        "Invalid sequence. Expected position " + expected +
-                                " but found " + positions.get(i));
+                        "Invalid sequence. Expected position "
+                                + expected
+                                + " but found "
+                                + positions.get(i));
             }
         }
     }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 
 import com.arqivame.storage.application.file.session.cancel.CancelUploadSessionUseCase;
 import com.arqivame.storage.application.file.session.cancel.DefaultCancelUploadSessionUseCase;
+import com.arqivame.storage.application.file.session.chunk.merge.DefaultMergeUploadSessionChunksUseCase;
+import com.arqivame.storage.application.file.session.chunk.merge.MergeUploadSessionChunksUseCase;
 import com.arqivame.storage.application.file.session.chunk.write.DefaultWriteUploadSessionChunkUseCase;
 import com.arqivame.storage.application.file.session.chunk.write.WriteUploadSessionChunkUseCase;
 import com.arqivame.storage.application.file.session.create.CreateUploadSessionUseCase;
@@ -15,8 +17,11 @@ import com.arqivame.storage.application.file.session.delete.mark.DefaultMarkUplo
 import com.arqivame.storage.application.file.session.delete.mark.MarkUploadSessionForDeletionUseCase;
 import com.arqivame.storage.application.file.session.delete.physical.DefaultPhysicalUploadSessionDeleteUseCase;
 import com.arqivame.storage.application.file.session.delete.physical.PhysicalUploadSessionDeleteUseCase;
+import com.arqivame.storage.application.file.session.process.initiate.DefaultInitiateUploadSessionProcessingUseCase;
+import com.arqivame.storage.application.file.session.process.initiate.InitiateUploadSessionProcessingUseCase;
 import com.arqivame.storage.domain.event.EventDispatcher;
 import com.arqivame.storage.domain.file.FileGateway;
+import com.arqivame.storage.domain.file.service.ChunkMergeService;
 import com.arqivame.storage.domain.file.service.StorageService;
 
 @Configuration
@@ -25,15 +30,18 @@ public class FileUseCaseConfig {
     private final FileGateway fileGateway;
 
     private final StorageService storageService;
+    private final ChunkMergeService chunkMergeService;
 
     private final EventDispatcher eventDispatcher;
 
     public FileUseCaseConfig(
             final FileGateway fileGateway,
             final StorageService storageService,
+            final ChunkMergeService chunkMergeService,
             final EventDispatcher eventDispatcher) {
         this.fileGateway = Objects.requireNonNull(fileGateway);
         this.storageService = Objects.requireNonNull(storageService);
+        this.chunkMergeService = Objects.requireNonNull(chunkMergeService);
         this.eventDispatcher = Objects.requireNonNull(eventDispatcher);
     }
 
@@ -71,6 +79,21 @@ public class FileUseCaseConfig {
                 eventDispatcher,
                 fileGateway,
                 storageService);
+    }
+
+    @Bean
+    InitiateUploadSessionProcessingUseCase initiateUploadSessionProcessingUseCase() {
+        return new DefaultInitiateUploadSessionProcessingUseCase(
+                eventDispatcher,
+                fileGateway);
+    }
+
+    @Bean
+    MergeUploadSessionChunksUseCase mergeUploadSessionChunksUseCase() {
+        return new DefaultMergeUploadSessionChunksUseCase(
+                eventDispatcher,
+                fileGateway,
+                chunkMergeService);
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/domain/service/FileDomainServiceConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/domain/service/FileDomainServiceConfig.java
@@ -5,7 +5,9 @@ import java.nio.file.Path;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.arqivame.storage.domain.file.service.ChunkMergeService;
 import com.arqivame.storage.domain.file.service.StorageService;
+import com.arqivame.storage.infrastructure.file.service.FileSystemChunkMergeService;
 import com.arqivame.storage.infrastructure.file.service.FileSystemStorageService;
 
 @Configuration
@@ -16,6 +18,11 @@ public class FileDomainServiceConfig {
     @Bean
     StorageService storageService() {
         return new FileSystemStorageService(Path.of(rootLocation));
+    }
+
+    @Bean
+    ChunkMergeService chunkMergeService() {
+        return new FileSystemChunkMergeService(Path.of(rootLocation));
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageConsumerConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageConsumerConfig.java
@@ -8,12 +8,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 
+import com.arqivame.storage.application.file.session.chunk.merge.MergeUploadSessionChunksUseCase;
 import com.arqivame.storage.application.file.session.delete.mark.MarkUploadSessionForDeletionUseCase;
 import com.arqivame.storage.application.file.session.delete.physical.PhysicalUploadSessionDeleteUseCase;
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionCanceledMessage;
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionMarkedForDeletionMessage;
+import com.arqivame.storage.infrastructure.file.model.FileUploadSessionProcessingInitiatedMessage;
 import com.arqivame.storage.infrastructure.messaging.consumer.rabbitmq.file.FileUploadSessionCanceledConsumer;
 import com.arqivame.storage.infrastructure.messaging.consumer.rabbitmq.file.FileUploadSessionMarkedForDeletionConsumer;
+import com.arqivame.storage.infrastructure.messaging.consumer.rabbitmq.file.FileUploadSessionProcessingInitiatedConsumer;
 import com.arqivame.storage.infrastructure.messaging.producer.MessageProducer;
 
 @Configuration
@@ -39,6 +42,17 @@ public class MessageConsumerConfig {
                 maxAttempts,
                 errorMessageProducer,
                 physicalUploadSessionDeleteUseCase);
+    }
+
+    @Bean
+    Consumer<Message<FileUploadSessionProcessingInitiatedMessage>> fileUploadSessionProcessingInitiatedConsumer(
+            @Value("${application.messaging.consumer.file-upload-session-processing-initiated-event.max-attempts}") final Long maxAttempts,
+            @Qualifier("fileUploadSessionProcessingInitiatedEventError") final MessageProducer<FileUploadSessionProcessingInitiatedMessage> errorMessageProducer,
+            final MergeUploadSessionChunksUseCase mergeUploadSessionChunksUseCase) {
+        return new FileUploadSessionProcessingInitiatedConsumer(
+                maxAttempts,
+                errorMessageProducer,
+                mergeUploadSessionChunksUseCase);
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageProducerConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageProducerConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Primary;
 
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionCanceledMessage;
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionMarkedForDeletionMessage;
+import com.arqivame.storage.infrastructure.file.model.FileUploadSessionProcessingInitiatedMessage;
 import com.arqivame.storage.infrastructure.messaging.producer.MessageProducer;
 import com.arqivame.storage.infrastructure.messaging.producer.springcloud.SpringCloudMessageProducer;
 
@@ -41,6 +42,17 @@ public class MessageProducerConfig {
     @Bean
     MessageProducer<FileUploadSessionMarkedForDeletionMessage> fileUploadSessionMarkedForDeletionEventError() {
         return new SpringCloudMessageProducer<>(streamBridge, "fileUploadSessionMarkedForDeletionEventError-out-0");
+    }
+
+    @Bean
+    @Primary
+    MessageProducer<FileUploadSessionProcessingInitiatedMessage> fileUploadSessionProcessingInitiatedEvent() {
+        return new SpringCloudMessageProducer<>(streamBridge, "fileUploadSessionProcessingInitiatedEvent-out-0");
+    }
+
+    @Bean
+    MessageProducer<FileUploadSessionProcessingInitiatedMessage> fileUploadSessionProcessingInitiatedEventError() {
+        return new SpringCloudMessageProducer<>(streamBridge, "fileUploadSessionProcessingInitiatedEventError-out-0");
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/event/FileUploadSessionProcessingInitiatedEventHandler.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/event/FileUploadSessionProcessingInitiatedEventHandler.java
@@ -1,0 +1,28 @@
+package com.arqivame.storage.infrastructure.file.event;
+
+import org.springframework.stereotype.Component;
+
+import com.arqivame.storage.domain.event.EventHandler;
+import com.arqivame.storage.domain.file.event.FileUploadSessionProcessingInitiatedEvent;
+import com.arqivame.storage.infrastructure.file.model.FileUploadSessionProcessingInitiatedMessage;
+import com.arqivame.storage.infrastructure.file.presenter.FilePresenter;
+import com.arqivame.storage.infrastructure.messaging.producer.MessageProducer;
+
+@Component
+public class FileUploadSessionProcessingInitiatedEventHandler
+        extends EventHandler<FileUploadSessionProcessingInitiatedEvent> {
+
+    private final MessageProducer<FileUploadSessionProcessingInitiatedMessage> messageProducer;
+
+    public FileUploadSessionProcessingInitiatedEventHandler(
+            final MessageProducer<FileUploadSessionProcessingInitiatedMessage> messageProducer) {
+        super(FileUploadSessionProcessingInitiatedEvent.eventKey());
+        this.messageProducer = messageProducer;
+    }
+
+    @Override
+    public void handle(final FileUploadSessionProcessingInitiatedEvent event) {
+        messageProducer.produce(FilePresenter.present(event));
+    }
+
+}

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/model/FileUploadSessionProcessingInitiatedMessage.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/model/FileUploadSessionProcessingInitiatedMessage.java
@@ -1,0 +1,18 @@
+package com.arqivame.storage.infrastructure.file.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import com.arqivame.storage.infrastructure.event.model.EventMessage;
+
+public record FileUploadSessionProcessingInitiatedMessage(
+        EventMessage.Metadata metadata,
+        Data data)
+        implements EventMessage<FileUploadSessionProcessingInitiatedMessage.Data> {
+
+    public record Data(
+            UUID fileId,
+            UUID sessionId) implements Serializable {
+    }
+
+}

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/presenter/FilePresenter.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/presenter/FilePresenter.java
@@ -2,9 +2,11 @@ package com.arqivame.storage.infrastructure.file.presenter;
 
 import com.arqivame.storage.domain.file.event.FileUploadSessionCanceledEvent;
 import com.arqivame.storage.domain.file.event.FileUploadSessionMarkedForDeletionEvent;
+import com.arqivame.storage.domain.file.event.FileUploadSessionProcessingInitiatedEvent;
 import com.arqivame.storage.infrastructure.event.presenter.EventPresenter;
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionCanceledMessage;
 import com.arqivame.storage.infrastructure.file.model.FileUploadSessionMarkedForDeletionMessage;
+import com.arqivame.storage.infrastructure.file.model.FileUploadSessionProcessingInitiatedMessage;
 
 public interface FilePresenter {
 
@@ -17,6 +19,11 @@ public interface FilePresenter {
         return new FileUploadSessionMarkedForDeletionMessage(EventPresenter.present(event), toData(event.getData()));
     }
 
+    public static FileUploadSessionProcessingInitiatedMessage present(
+            final FileUploadSessionProcessingInitiatedEvent event) {
+        return new FileUploadSessionProcessingInitiatedMessage(EventPresenter.present(event), toData(event.getData()));
+    }
+
     private static FileUploadSessionCanceledMessage.Data toData(final FileUploadSessionCanceledEvent.Data eventData) {
         return new FileUploadSessionCanceledMessage.Data(
                 eventData.fileId(),
@@ -27,6 +34,13 @@ public interface FilePresenter {
     private static FileUploadSessionMarkedForDeletionMessage.Data toData(
             final FileUploadSessionMarkedForDeletionEvent.Data eventData) {
         return new FileUploadSessionMarkedForDeletionMessage.Data(
+                eventData.fileId(),
+                eventData.sessionId());
+    }
+
+    private static FileUploadSessionProcessingInitiatedMessage.Data toData(
+            final FileUploadSessionProcessingInitiatedEvent.Data eventData) {
+        return new FileUploadSessionProcessingInitiatedMessage.Data(
                 eventData.fileId(),
                 eventData.sessionId());
     }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
@@ -1,6 +1,7 @@
 package com.arqivame.storage.infrastructure.file.service;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -19,26 +20,45 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
     }
 
     @Override
-    public void mergeChunks(final StorageKey finalFileKey, final Set<ChunkInfo> chunks) {
+    public MergeResult mergeChunks(final StorageKey finalFileKey, final Set<ChunkInfo> chunks) {
 
-        final Path finalFilePath = toPath(rootLocation, finalFileKey);
+        final Path finalFilePath = toPath(finalFileKey);
 
         final Set<SequentialIterator.Item<Path>> items = chunks
                 .stream()
-                .map(chunk -> SequentialIterator.Item.of(toPath(rootLocation, chunk.key()), chunk.index()))
+                .map(chunk -> SequentialIterator.Item.of(toPath(chunk.key()), chunk.index()))
                 .collect(Collectors.toSet());
 
         final SequentialIterator<Path> iterator = SequentialIterator.of(items);
 
-        FileSystemUtils.append(finalFilePath, iterator);
+        try {
+            FileSystemUtils.append(finalFilePath, iterator);
+        } catch (Exception e) {
+            final Set<ChunkInfo> nonMergedChunks = new HashSet<>();
+            iterator.forEachRemaining(item -> nonMergedChunks.add(findChunkInfo(chunks, fromPath(item))));
+            MergeResult.partialMerge(nonMergedChunks);
+        }
 
+        return MergeResult.allMerged();
     }
 
-    private static Path toPath(final Path rootLocation, final StorageKey storageKey) {
-        // TODO ver se mantem a lógica de lastSegment
-        final String fullKey = storageKey.getFullKey();
-        final String lastSegment = storageKey.lastSegment();
-        return rootLocation.resolve(fullKey).resolve(lastSegment);
+    private static ChunkInfo findChunkInfo(final Set<ChunkInfo> chunkInfos, final StorageKey storageKey) {
+        return chunkInfos
+                .stream()
+                .filter(chunkInfo -> chunkInfo.key().equals(storageKey))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Chunk with index "
+                                + storageKey
+                                + " not found in the provided chunks set."));
+    }
+
+    private StorageKey fromPath(final Path path) {
+        return StorageKey.of(rootLocation.relativize(path).toString());
+    }
+
+    private Path toPath(final StorageKey storageKey) {
+        return rootLocation.resolve(storageKey.getFullKey());
     }
 
 }

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
@@ -25,10 +25,7 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
     public MergeResult mergeChunks(
             final StorageKey finalFileKey,
             final Set<ChunkInfo> chunks,
-            final Long firstChunkSize,
-            final Long lastChunkSize) {
-
-        final Path finalFilePath = toPath(finalFileKey);
+            final Long firstChunkSize) {
 
         final Set<SequentialIterator.Item<ChunkInfo>> items = chunks
                 .stream()
@@ -38,7 +35,7 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
         final SequentialIterator<ChunkInfo> iterator = SequentialIterator.of(items);
 
         try (final FileChannel outputChannel = FileSystemUtils.opeChannel(
-                finalFilePath,
+                toPath(finalFileKey),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE)) {
 

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
@@ -1,0 +1,44 @@
+package com.arqivame.storage.infrastructure.file.service;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.arqivame.storage.domain.file.service.ChunkMergeService;
+import com.arqivame.storage.domain.file.service.StorageKey;
+import com.arqivame.storage.infrastructure.commons.FileSystemUtils;
+import com.arqivame.storage.infrastructure.commons.SequentialIterator;
+
+public class FileSystemChunkMergeService implements ChunkMergeService {
+
+    private final Path rootLocation;
+
+    public FileSystemChunkMergeService(final Path rootLocation) {
+        this.rootLocation = Objects.requireNonNull(rootLocation);
+    }
+
+    @Override
+    public void mergeChunks(final StorageKey finalFileKey, final Set<ChunkInfo> chunks) {
+
+        final Path finalFilePath = toPath(rootLocation, finalFileKey);
+
+        final Set<SequentialIterator.Item<Path>> items = chunks
+                .stream()
+                .map(chunk -> SequentialIterator.Item.of(toPath(rootLocation, chunk.key()), chunk.index()))
+                .collect(Collectors.toSet());
+
+        final SequentialIterator<Path> iterator = SequentialIterator.of(items);
+
+        FileSystemUtils.append(finalFilePath, iterator);
+
+    }
+
+    private static Path toPath(final Path rootLocation, final StorageKey storageKey) {
+        // TODO ver se mantem a lógica de lastSegment
+        final String fullKey = storageKey.getFullKey();
+        final String lastSegment = storageKey.lastSegment();
+        return rootLocation.resolve(fullKey).resolve(lastSegment);
+    }
+
+}

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
@@ -22,7 +22,11 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
     }
 
     @Override
-    public MergeResult mergeChunks(final StorageKey finalFileKey, final Set<ChunkInfo> chunks) {
+    public MergeResult mergeChunks(
+            final StorageKey finalFileKey,
+            final Set<ChunkInfo> chunks,
+            final Long firstChunkSize,
+            final Long lastChunkSize) {
 
         final Path finalFilePath = toPath(finalFileKey);
 
@@ -33,18 +37,29 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
 
         final SequentialIterator<ChunkInfo> iterator = SequentialIterator.of(items);
 
-        try (final FileChannel outputChannel = FileSystemUtils.opeChannel(finalFilePath, StandardOpenOption.CREATE,
+        try (final FileChannel outputChannel = FileSystemUtils.opeChannel(
+                finalFilePath,
+                StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE)) {
 
             while (iterator.hasNext()) {
-                try (final FileChannel inputChannel = FileSystemUtils.opeChannel(
-                        toPath(iterator.next().key()),
-                        StandardOpenOption.READ)) {
-                    FileSystemUtils.append(outputChannel.position(), outputChannel, inputChannel);
-                }
-            }
 
-            // TODO notificar que chunk foi mesclado aqui??
+                final ChunkInfo chunkInfo = iterator.next();
+
+                if (!FileSystemUtils.exists(toPath(chunkInfo.key())))
+                    continue;
+
+                try (final FileChannel inputChannel = FileSystemUtils.opeChannel(
+                        toPath(chunkInfo.key()),
+                        StandardOpenOption.READ)) {
+
+                    final Long offset = (chunkInfo.index() * firstChunkSize);
+                    FileSystemUtils.append(offset, outputChannel, inputChannel);
+
+                }
+
+                FileSystemUtils.delete(toPath(chunkInfo.key()));
+            }
 
         } catch (Exception e) {
             final Set<ChunkInfo> nonMergedChunks = new HashSet<>();

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemChunkMergeService.java
@@ -1,6 +1,8 @@
 package com.arqivame.storage.infrastructure.file.service;
 
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -24,37 +26,33 @@ public class FileSystemChunkMergeService implements ChunkMergeService {
 
         final Path finalFilePath = toPath(finalFileKey);
 
-        final Set<SequentialIterator.Item<Path>> items = chunks
+        final Set<SequentialIterator.Item<ChunkInfo>> items = chunks
                 .stream()
-                .map(chunk -> SequentialIterator.Item.of(toPath(chunk.key()), chunk.index()))
+                .map(chunk -> SequentialIterator.Item.of(chunk, chunk.index()))
                 .collect(Collectors.toSet());
 
-        final SequentialIterator<Path> iterator = SequentialIterator.of(items);
+        final SequentialIterator<ChunkInfo> iterator = SequentialIterator.of(items);
 
-        try {
-            FileSystemUtils.append(finalFilePath, iterator);
+        try (final FileChannel outputChannel = FileSystemUtils.opeChannel(finalFilePath, StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE)) {
+
+            while (iterator.hasNext()) {
+                try (final FileChannel inputChannel = FileSystemUtils.opeChannel(
+                        toPath(iterator.next().key()),
+                        StandardOpenOption.READ)) {
+                    FileSystemUtils.append(outputChannel.position(), outputChannel, inputChannel);
+                }
+            }
+
+            // TODO notificar que chunk foi mesclado aqui??
+
         } catch (Exception e) {
             final Set<ChunkInfo> nonMergedChunks = new HashSet<>();
-            iterator.forEachRemaining(item -> nonMergedChunks.add(findChunkInfo(chunks, fromPath(item))));
+            iterator.forEachRemaining(item -> nonMergedChunks.add(item));
             MergeResult.partialMerge(nonMergedChunks);
         }
 
         return MergeResult.allMerged();
-    }
-
-    private static ChunkInfo findChunkInfo(final Set<ChunkInfo> chunkInfos, final StorageKey storageKey) {
-        return chunkInfos
-                .stream()
-                .filter(chunkInfo -> chunkInfo.key().equals(storageKey))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException(
-                        "Chunk with index "
-                                + storageKey
-                                + " not found in the provided chunks set."));
-    }
-
-    private StorageKey fromPath(final Path path) {
-        return StorageKey.of(rootLocation.relativize(path).toString());
     }
 
     private Path toPath(final StorageKey storageKey) {

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemStorageService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemStorageService.java
@@ -4,9 +4,7 @@ import static com.arqivame.storage.infrastructure.commons.InputStreamUtils.bound
 import static com.arqivame.storage.infrastructure.commons.InputStreamUtils.digestible;
 import static com.arqivame.storage.infrastructure.commons.InputStreamUtils.throttled;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Objects;
@@ -35,11 +33,7 @@ public class FileSystemStorageService implements StorageService {
 
         final Path sessionLocation = rootLocation.resolve(fullKey).resolve(lastSegment);
 
-        try {
-            Files.delete(sessionLocation);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to delete storage key: " + fullKey, e);
-        }
+        FileSystemUtils.delete(sessionLocation);
 
     }
 

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemStorageService.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/file/service/FileSystemStorageService.java
@@ -29,9 +29,8 @@ public class FileSystemStorageService implements StorageService {
     public void delete(final StorageKey key) {
 
         final String fullKey = key.getFullKey();
-        final String lastSegment = key.lastSegment();
 
-        final Path sessionLocation = rootLocation.resolve(fullKey).resolve(lastSegment);
+        final Path sessionLocation = rootLocation.resolve(fullKey);
 
         FileSystemUtils.delete(sessionLocation);
 
@@ -46,15 +45,13 @@ public class FileSystemStorageService implements StorageService {
             final Algorithm checksumAlgorithm) {
 
         final String fullKey = key.getFullKey();
-        final String lastSegment = key.lastSegment();
 
-        final Path sessionLocation = rootLocation.resolve(fullKey);
+        final Path storageLocation = rootLocation.resolve(fullKey);
 
         final MessageDigest digest = MessageDigestUtils.create(checksumAlgorithm);
 
         write(
-                sessionLocation,
-                lastSegment,
+                storageLocation,
                 inputStream,
                 sizeInBytes,
                 bytesPerSecondsWrittenRate,
@@ -65,8 +62,7 @@ public class FileSystemStorageService implements StorageService {
     }
 
     private static void write(
-            final Path sessionLocation,
-            final String lastSegment,
+            final Path fileOutputPath,
             final InputStream inputStream,
             final Long sizeInBytes,
             final Long bytesPerSecondsWrittenRate,
@@ -76,10 +72,7 @@ public class FileSystemStorageService implements StorageService {
                 throttled(bounded(inputStream, sizeInBytes), bytesPerSecondsWrittenRate),
                 digest)) {
 
-            FileSystemUtils.write(
-                    sessionLocation,
-                    lastSegment,
-                    is);
+            FileSystemUtils.write(fileOutputPath, is);
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to write input stream", e);

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/messaging/consumer/rabbitmq/file/FileUploadSessionProcessingInitiatedConsumer.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/messaging/consumer/rabbitmq/file/FileUploadSessionProcessingInitiatedConsumer.java
@@ -1,0 +1,39 @@
+package com.arqivame.storage.infrastructure.messaging.consumer.rabbitmq.file;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.messaging.Message;
+
+import com.arqivame.storage.application.file.session.chunk.merge.MergeUploadSessionChunksInput;
+import com.arqivame.storage.application.file.session.chunk.merge.MergeUploadSessionChunksUseCase;
+import com.arqivame.storage.infrastructure.file.model.FileUploadSessionProcessingInitiatedMessage;
+import com.arqivame.storage.infrastructure.messaging.consumer.rabbitmq.RabbitMQMessageConsumer;
+import com.arqivame.storage.infrastructure.messaging.producer.MessageProducer;
+
+public class FileUploadSessionProcessingInitiatedConsumer
+        extends RabbitMQMessageConsumer<FileUploadSessionProcessingInitiatedMessage> {
+
+    private final MergeUploadSessionChunksUseCase mergeUploadSessionChunksUseCase;
+
+    public FileUploadSessionProcessingInitiatedConsumer(
+            final Long maxRetryAttempts,
+            final MessageProducer<FileUploadSessionProcessingInitiatedMessage> errorMessageProducer,
+            final MergeUploadSessionChunksUseCase mergeUploadSessionChunksUseCase) {
+        super(maxRetryAttempts, errorMessageProducer, Set.of());
+        this.mergeUploadSessionChunksUseCase = Objects.requireNonNull(mergeUploadSessionChunksUseCase);
+    }
+
+    @Override
+    public void consume(final Message<FileUploadSessionProcessingInitiatedMessage> message) {
+
+        final FileUploadSessionProcessingInitiatedMessage event = message.getPayload();
+        final FileUploadSessionProcessingInitiatedMessage.Data data = event.data();
+
+        final MergeUploadSessionChunksInput input = new MergeUploadSessionChunksInput(data.fileId(), data.sessionId());
+
+        mergeUploadSessionChunksUseCase.execute(input);
+
+    }
+
+}

--- a/infrastructure/src/main/resources/application-rabbitmq.yml
+++ b/infrastructure/src/main/resources/application-rabbitmq.yml
@@ -39,6 +39,18 @@ spring:
               destination: storage.exchange.error
               routingKeyExpression: "'storage.file:upload-session.marked-for-deletion'"
               queueNameGroupOnly: true
+          ## File Upload Session Processing Initiated Event
+          fileUploadSessionProcessingInitiatedEvent-out-0:
+            producer:
+              exchangeType: topic
+              destination: storage.exchange
+              routingKeyExpression: "'storage.file:upload-session.processing-initiated'"
+          fileUploadSessionProcessingInitiatedEventError-out-0:
+            producer:
+              exchangeType: topic
+              destination: storage.exchange.error
+              routingKeyExpression: "'storage.file:upload-session.processing-initiated'"
+              queueNameGroupOnly: true
           # Incoming RabbitMQ bindings
           ## File Upload Session Canceled Event
           fileUploadSessionCanceledEvent-in-0:
@@ -64,6 +76,19 @@ spring:
               deadLetterQueueName: storage.file:upload-session.marked-for-deletion.queue.wait
               dlqDeadLetterExchange: storage.exchange
               dlqDeadLetterRoutingKey: storage.file:upload-session.marked-for-deletion
+              republishToDlq: false
+              dlqTtl: 5000
+          ## File Upload Session Processing Initiated Event
+          fileUploadSessionProcessingInitiatedEvent-in-0:
+            consumer:
+              exchangeType: topic
+              bindingRoutingKey: storage.file:upload-session.processing-initiated
+              queueNameGroupOnly: true
+              autoBindDlq: true
+              deadLetterExchange: storage.exchange.wait
+              deadLetterQueueName: storage.file:upload-session.processing-initiated.queue.wait
+              dlqDeadLetterExchange: storage.exchange
+              dlqDeadLetterRoutingKey: storage.file:upload-session.processing-initiated
               republishToDlq: false
               dlqTtl: 5000
 

--- a/infrastructure/src/main/resources/application-spring-cloud.yml
+++ b/infrastructure/src/main/resources/application-spring-cloud.yml
@@ -1,12 +1,13 @@
 spring:
   cloud:
     function:
-      definition: fileUploadSessionCanceledConsumer;fileUploadSessionMarkedForDeletionConsumer
+      definition: fileUploadSessionCanceledConsumer;fileUploadSessionMarkedForDeletionConsumer;fileUploadSessionProcessingInitiatedConsumer
     stream:
       function:
         bindings:
           fileUploadSessionCanceledConsumer-in-0: fileUploadSessionCanceledEvent-in-0
           fileUploadSessionMarkedForDeletionConsumer-in-0: fileUploadSessionMarkedForDeletionEvent-in-0
+          fileUploadSessionProcessingInitiatedConsumer-in-0: fileUploadSessionProcessingInitiatedEvent-in-0
       default:
         content-type: application/json
       bindings:
@@ -25,6 +26,13 @@ spring:
           destination: storage.exchange.error
           producer:
             requiredGroups: storage.file:upload-session.marked-for-deletion.queue.error
+        ## File Upload Session Processing Initiated Event
+        fileUploadSessionProcessingInitiatedEvent-out-0:
+          destination: storage.exchange
+        fileUploadSessionProcessingInitiatedEventError-out-0:
+          destination: storage.exchange.error
+          producer:
+            requiredGroups: storage.file:upload-session.processing-initiated.queue.error
         # Incoming bindings
         ## File Upload Session Canceled Event
         fileUploadSessionCanceledEvent-in-0:
@@ -40,3 +48,12 @@ spring:
           consumer:
             max-attempts: 1
             concurrency: ${application.messaging.consumer.file-upload-session-marked-for-deletion-event.concurrency}
+        ## File Upload Session Processing Initiated Event
+        fileUploadSessionProcessingInitiatedEvent-in-0:
+          destination: storage.exchange
+          group: storage.file:upload-session.processing-initiated.queue
+          consumer:
+            max-attempts: 1
+            concurrency: ${application.messaging.consumer.file-upload-session-processing-initiated-event.concurrency}
+
+

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -23,3 +23,6 @@ application:
       file-upload-session-marked-for-deletion-event:
         concurrency: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_MARKED_FOR_DELETION_CONCURRENCY:1}
         max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_MARKED_FOR_DELETION_MAX_ATTEMPTS:1}
+      file-upload-session-processing-initiated-event:
+        concurrency: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_PROCESSING_INITIATED_CONCURRENCY:1}
+        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_PROCESSING_INITIATED_MAX_ATTEMPTS:1}


### PR DESCRIPTION
### Adiciona fluxo de processamento de upload e merge de chunks

Este PR introduz o fluxo de processamento de sessões de upload, permitindo iniciar e concluir o processamento e realizar o merge dos chunks enviados.

**Principais mudanças:**

* Adição de casos de uso para iniciar o processamento da sessão de upload e realizar o merge dos chunks
* Extensão dos modelos de domínio `File` e `UploadSession` com novos estados e validações de processamento
* Introdução de abstrações para merge de chunks e tratamento de resultados
* Inclusão de eventos de domínio e exceções específicas para cenários de processamento e merge
* Integração temporária do novo fluxo na camada de API 'TestController'

Este PR estabelece a base para um fluxo de upload mais robusto, consistente e orientado a eventos.
