### PR TITLE
feat: implementa Redis como opção de 'ConcurrencyTracker'

### DIFF
--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.7.7'
     implementation 'com.h2database:h2:2.4.240'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/concurrency/inmem/InMemoryConcurrencyTracker.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/concurrency/inmem/InMemoryConcurrencyTracker.java
@@ -6,12 +6,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.arqivame.storage.application.port.ConcurrencyTracker;
 import com.arqivame.storage.domain.Identifier;
 
 @Component
+@ConditionalOnProperty(name = "application.vendor.concurrency-tracker", havingValue = "inmemory")
 public class InMemoryConcurrencyTracker implements ConcurrencyTracker {
 
     private final ConcurrentMap<Key, AtomicInteger> counters = new ConcurrentHashMap<>();

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/concurrency/redis/RedisConcurrencyTracker.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/concurrency/redis/RedisConcurrencyTracker.java
@@ -1,0 +1,66 @@
+package com.arqivame.storage.infrastructure.concurrency.redis;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import com.arqivame.storage.application.port.ConcurrencyTracker;
+import com.arqivame.storage.domain.Identifier;
+
+public class RedisConcurrencyTracker implements ConcurrencyTracker {
+
+    private final RedisTemplate<String, Integer> redisTemplate;
+    private final RedisScript<Integer> decrementPositiveScript;
+    private final ValueOperations<String, Integer> valueOperations;
+    private final Duration ttl;
+
+    public RedisConcurrencyTracker(
+            final RedisTemplate<String, Integer> redisTemplate,
+            final RedisScript<Integer> decrementPositiveScript,
+            final Duration ttl) {
+        this.redisTemplate = requireNonNull(redisTemplate);
+        this.decrementPositiveScript = requireNonNull(decrementPositiveScript);
+        this.valueOperations = this.redisTemplate.opsForValue();
+        this.ttl = requireNonNull(ttl);
+    }
+
+    @Override
+    public void increment(Identifier<?> key, String... tags) {
+        valueOperations.increment(buildKey(key, tags));
+        setTtl(buildKey(key, tags));
+    }
+
+    @Override
+    public void decrement(Identifier<?> key, String... tags) {
+        redisTemplate.execute(
+                decrementPositiveScript,
+                Collections.singletonList(buildKey(key, tags)));
+        setTtl(buildKey(key, tags));
+    }
+
+    @Override
+    public Integer getCurrentCount(Identifier<?> key, String... tags) {
+        return Optional.ofNullable(valueOperations.get(buildKey(key, tags))).orElse(0);
+    }
+
+    private static String buildKey(Identifier<?> identifier, String... tags) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(identifier.getStringValue());
+        if (tags != null)
+            for (String tag : tags)
+                sb.append(":").append(tag);
+
+        return sb.toString();
+    }
+
+    private void setTtl(final String key) {
+        redisTemplate.expire(key, ttl);
+    }
+
+}

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
@@ -22,14 +22,11 @@ import com.arqivame.storage.application.usecase.file.session.upload.create.Creat
 import com.arqivame.storage.application.usecase.file.session.upload.create.DefaultCreateUploadSessionUseCase;
 import com.arqivame.storage.domain.event.EventDispatcher;
 import com.arqivame.storage.domain.file.FileGateway;
-import com.arqivame.storage.infrastructure.storage.service.StorageService;
 
 @Configuration
 public class FileUseCaseConfig {
 
     private final FileGateway fileGateway;
-
-    private final StorageService storageService;
 
     private final ConcurrencyTracker concurrencyTracker;
     private final ChunkWriter chunkWriter;
@@ -39,13 +36,11 @@ public class FileUseCaseConfig {
 
     public FileUseCaseConfig(
             final FileGateway fileGateway,
-            final StorageService storageService,
             final ConcurrencyTracker concurrencyTracker,
             final ChunkWriter chunkWriter,
             final ChunkReader chunkReader,
             final EventDispatcher eventDispatcher) {
         this.fileGateway = Objects.requireNonNull(fileGateway);
-        this.storageService = Objects.requireNonNull(storageService);
         this.concurrencyTracker = Objects.requireNonNull(concurrencyTracker);
         this.chunkWriter = Objects.requireNonNull(chunkWriter);
         this.chunkReader = Objects.requireNonNull(chunkReader);

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageConsumerConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/messaging/MessageConsumerConfig.java
@@ -25,17 +25,14 @@ public class MessageConsumerConfig {
 
     private final FileGateway fileGateway;
     private final FileAssembler fileAssembler;
-    private final FinalizerFileProcessingService finalizerFileProcessingService;
     private final ChunkStorageCleaner chunkStorageCleaner;
 
     public MessageConsumerConfig(
             final FileGateway fileGateway,
             final FileAssembler fileAssembler,
-            final FinalizerFileProcessingService finalizerFileProcessingService,
             final ChunkStorageCleaner chunkStorageCleaner) {
         this.fileGateway = fileGateway;
         this.fileAssembler = fileAssembler;
-        this.finalizerFileProcessingService = finalizerFileProcessingService;
         this.chunkStorageCleaner = chunkStorageCleaner;
     }
 

--- a/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/redis/RedisConfig.java
+++ b/infrastructure/src/main/java/com/arqivame/storage/infrastructure/configuration/redis/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.arqivame.storage.infrastructure.configuration.redis;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.arqivame.storage.application.port.ConcurrencyTracker;
+import com.arqivame.storage.infrastructure.concurrency.redis.RedisConcurrencyTracker;
+
+@Configuration
+@ConditionalOnProperty(name = "application.vendor.concurrency-tracker", havingValue = "redis")
+public class RedisConfig {
+
+    @Bean
+    RedisTemplate<String, Integer> redisTemplate(final RedisConnectionFactory factory) {
+        final RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        return template;
+    }
+
+    @Bean
+    RedisScript<Integer> decrementPositiveScript() {
+
+        final String script = """
+                local current = redis.call('get', KEYS[1])
+                if not current or tonumber(current) <= 0 then
+                    return 0
+                else
+                    return redis.call('decr', KEYS[1])
+                end
+                """;
+
+        return new DefaultRedisScript<>(script, Integer.class);
+    }
+
+    @Bean
+    ConcurrencyTracker redisConcurrencyTracker(
+            final RedisTemplate<String, Integer> redisTemplate,
+            final RedisScript<Integer> decrementPositiveScript,
+            final @Value("${redis.concurrency.tracker.ttl-seconds}") Long ttlSeconds) {
+        return new RedisConcurrencyTracker(redisTemplate, decrementPositiveScript, Duration.ofSeconds(ttlSeconds));
+    }
+
+}

--- a/infrastructure/src/main/resources/application-redis.yml
+++ b/infrastructure/src/main/resources/application-redis.yml
@@ -1,0 +1,12 @@
+spring:
+  data:
+    redis:
+      host: ${redis.host}
+      port: ${redis.port}
+
+redis:
+  host: ${REDIS_HOST:localhost}
+  port: ${REDIS_PORT:6379}
+  concurrency:
+    tracker:
+      ttl-seconds: ${REDIS_CONCURRENCY_TRACKER_TTL_SECONDS:60}

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       - spring-cloud
       - ${application.vendor.database}
       - ${application.vendor.messaging}
+      - ${application.vendor.concurrency-tracker}
 
 application:
   name: storage-api
@@ -15,14 +16,15 @@ application:
   vendor:
     database: ${STORAGE_VENDOR_DATABASE:postgres}
     messaging: ${STORAGE_VENDOR_MESSAGING:rabbitmq}
+    concurrency-tracker: ${STORAGE_VENDOR_CONCURRENCY_TRACKER:redis}
   messaging:
     consumer:
       file-upload-session-completed-event:
         concurrency: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_COMPLETED_CONCURRENCY:1}
-        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_COMPLETED_MAX_ATTEMPTS:1}
+        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_COMPLETED_MAX_ATTEMPTS:5}
       file-upload-session-closed-event:
         concurrency: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_CLOSED_CONCURRENCY:1}
-        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_CLOSED_MAX_ATTEMPTS:1}
+        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_CLOSED_MAX_ATTEMPTS:5}
       file-upload-session-aborted-event:
         concurrency: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_ABORTED_CONCURRENCY:1}
-        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_ABORTED_MAX_ATTEMPTS:1}
+        max-attempts: ${STORAGE_CONSUMER_FILE_UPLOAD_SESSION_ABORTED_MAX_ATTEMPTS:5}


### PR DESCRIPTION
**Resumo**

Este PR adiciona uma implementação de controle de concorrência baseada em Redis ao serviço de storage, tornando o `ConcurrencyTracker` configurável via propriedades da aplicação. A solução permite alternar entre Redis e memória conforme o ambiente, além de melhorar a resiliência do processamento de sessões.

**Principais mudanças**

* Adicionada a implementação `RedisConcurrencyTracker`, utilizando Redis para controle de concorrência com suporte a TTL.
* Incluída configuração de Redis (`RedisConfig`), com beans, `RedisTemplate` e script Lua para decremento seguro.
* Adicionada dependência do Spring Boot Redis Starter.
* Tornado o `ConcurrencyTracker` plugável via propriedade `application.vendor.concurrency-tracker` (padrão: Redis).
* Criado `application-redis.yml` com configurações de conexão e TTL do Redis.
* Configuração condicional de beans para alternar entre `InMemoryConcurrencyTracker` e Redis.
* Aumentado o número de tentativas dos consumers de sessão de upload de 1 para 5.
* Pequena refatoração removendo parâmetros de construtor não utilizados em classes de configuração.

**Impacto**

* Suporte a controle de concorrência distribuído.
* Maior flexibilidade de configuração por ambiente.
* Melhoria na robustez do processamento de arquivos.
